### PR TITLE
Add rockylinux:latest-8 image/tag

### DIFF
--- a/.github/helperScripts/updateBuildPush.sh
+++ b/.github/helperScripts/updateBuildPush.sh
@@ -4,8 +4,12 @@
 # that is up to date with the version given in the --upstream argument; update,
 # build, and push to both github branch and dockerhub if necessary
 
+# Also, seperately check, update, build, and push the most recent Rocky8
+# version, as Rocky9 seems to not be fully reliable yet
+
 USAGE='
 ./updateBuildPush -u|--upstream <upstream-tag> \
+	-8|--rocky8 <upstream-rocky8-tag \
 	-i|--image <docker-image-name> \
 	-t|--token <dockerhub-token> \
 	-s|--user <dockerhub-user>
@@ -17,6 +21,10 @@ do
 	case $key in
 		-u|--upstream)
 			UPSTREAM=$2
+			shift
+			;;
+		-8|--rocky8)
+			UPSTREAM8=$2
 			shift
 			;;
 		-i|--image)
@@ -39,7 +47,7 @@ do
 	shift
 done
 
-if [[ -z "$UPSTREAM" || -z "$IMAGENAME" || -z "$REGISTRYPWD" || -z "$REGISTRYUSER" ]]; then
+if [[ -z "$UPSTREAM" || -z "$UPSTREAM8" || -z "$IMAGENAME" || -z "$REGISTRYPWD" || -z "$REGISTRYUSER" ]]; then
 	echo "Invalid number of arguments"
 	echo $USAGE
 	exit 1
@@ -53,7 +61,7 @@ BRANCHES=("master")
 ROCKYPATH="./openstack/rocky"
 
 git config --global user.name 'Github Actions'
-git config --global user.email 'respinoza@ucar.edu'
+git config --global user.email 'respinoza@ucar.edu'	
 
 for BRANCH in "${BRANCHES[@]}"
 do
@@ -62,7 +70,11 @@ do
 	echo "#######################################"
 	git checkout $BRANCH || git checkout -b $BRANCH
 	CURRENT=$(grep -i "FROM rockylinux" $ROCKYPATH/Dockerfile | awk -F ":" '{ print $2 }')
+	CURRENT8=$(grep -i "FROM rockylinux" $ROCKYPATH/Dockerfile.latest-8 | awk -F ":" '{ print $2 }')
 	echo "Current version: $CURRENT"
+	echo "Current Rocky8 version: $CURRENT8"
+
+	# Most up to date version
 	test "$CURRENT" = "$UPSTREAM" &&
 	up2date="true" || up2date="false"
 	echo "Up to date with latest version ($UPSTREAM)?"; echo $up2date
@@ -85,6 +97,30 @@ do
         { docker logout && echo "Successfully pushed ${IMAGENAME}:$UPSTREAM"; } ||
         { docker logout && echo "Docker push failed" && exit 1; }
 	fi
+
+	# Most up to date Rocky8 version
+	test "$CURRENT8" = "$UPSTREAM8" &&
+	up2date8="true" || up2date8="false"
+	echo "Up to date with latest Rocky8 version ($UPSTREAM8)?"; echo $up2date8
+	if [[ "$up2date8" != "true" ]]; then
+		# Update Dockerfile
+		sed -e "s/FROM rockylinux:.*/FROM rockylinux:$UPSTREAM8/g" $ROCKYPATH/Dockerfile.latest-8 -i
+		grep -i "FROM" $ROCKYPATH/Dockerfile.latest-8
+		# Build image
+		docker build --no-cache -f Dockerfile.latest-8 -t ${IMAGENAME}:$UPSTREAM8 $ROCKYPATH
+		# Test image
+        docker run ${IMAGENAME}:$UPSTREAM8 | \
+        grep "Build successful!" || exit 1
+		# Push to git
+        git add . && git commit -m "Update to rockylinux:$UPSTREAM8" && \
+        git push origin $BRANCH
+		# Push to dockerhub
+        docker logout
+        echo $REGISTRYPWD | docker login -u $REGISTRYUSER --password-stdin
+        docker push ${IMAGENAME}:$UPSTREAM8 && \
+        { docker logout && echo "Successfully pushed ${IMAGENAME}:$UPSTREAM8"; } ||
+        { docker logout && echo "Docker push failed" && exit 1; }
+	fi
 done
 
 if [[ "$up2date" != "true" ]]; then
@@ -92,4 +128,11 @@ if [[ "$up2date" != "true" ]]; then
 	echo $REGISTRYPWD | docker login -u $REGISTRYUSER --password-stdin
 	docker tag ${IMAGENAME}:$UPSTREAM ${IMAGENAME}:latest && \
 	docker push ${IMAGENAME}:latest
+fi
+
+if [[ "$up2date8" != "true" ]]; then
+	docker logout
+	echo $REGISTRYPWD | docker login -u $REGISTRYUSER --password-stdin
+	docker tag ${IMAGENAME}:$UPSTREAM8 ${IMAGENAME}:latest-8 && \
+	docker push ${IMAGENAME}:latest-8
 fi

--- a/.github/workflows/update-rocky.yml
+++ b/.github/workflows/update-rocky.yml
@@ -45,10 +45,19 @@ jobs:
         echo $upstream
         echo "upstream=$upstream" >> $GITHUB_ENV
 
+    - name: Grab the most recent upstream 8.x version
+      run: |
+        echo $(${{ env.scriptsdir }}/dockertags.sh rockylinux | grep -v -e "latest" -e "minimal" | sort -Vr)
+        upstream8=$( ${{ env.scriptsdir }}/dockertags.sh rockylinux | grep -e "^8" | grep -v -e "latest" -e "minimal" | sort -Vr | head -n1 )
+        echo $upstream8
+        echo "upstream8=$upstream8" >> $GITHUB_ENV
+
+
     - name: Check, update, build, push
       run: |
         ./${{ env.scriptsdir }}/updateBuildPush.sh \
         -u ${{ env.upstream }} \
+        -8 ${{ env.upstream8 }} \
         -i ${{ secrets.imagename }} \
         -t ${{ secrets.registrypwd }} \
         -s ${{ secrets.registryuser }}

--- a/openstack/rocky/Dockerfile.latest-8
+++ b/openstack/rocky/Dockerfile.latest-8
@@ -1,0 +1,26 @@
+# The tag "8" corresponds to the most recent upstream Rocky8 tag
+FROM rockylinux:8
+
+###
+# Update the system. Install stuff.
+###
+
+# Install repo: Extra Packages for Enterprise Linux
+RUN yum upgrade -y && yum install -y epel-release
+
+# Desired packages for basic use
+RUN yum install -y sudo man man-pages vim nano git wget unzip ncurses procps \
+	htop python3 telnet openssh openssh-clients openssl findutils
+
+###
+# Create rocky user account and add to sudoers file
+###
+
+RUN useradd -ms /bin/bash rocky
+ENV HOME /home/rocky
+ENV USER rocky
+RUN echo "rocky ALL=NOPASSWD: ALL" >> /etc/sudoers
+WORKDIR $HOME
+USER rocky
+
+CMD echo 'Build successful! For interactive mode, run as "docker run -it unidata/rocky /bin/bash"'


### PR DESCRIPTION
The official rockylinux dockerhub repo now has a Rocky9 image, however
Rocky9 doesn't seem to quite yet have all the necessary packages in its
repos. A rockylinux:latest-8 tag is created to complement the
rockylinux:latest tag, which will have the most recent image (v9).